### PR TITLE
Initial commit of v0.1.0

### DIFF
--- a/payment-initiation-nz-changelog.md
+++ b/payment-initiation-nz-changelog.md
@@ -2,6 +2,11 @@
 
 ---
 
+## v0.1.0 - 23/03/2018
+
+* Changed base path to /open-banking/v0.1
+* Version bump specification to v0.1.0 to reflect MINOR change to stabilise for pilot
+
 ## v0.0.5 - 12/03/2018
 
 * Update BECSRemittance object to include DebtorName in reference information.  This is particularly to support the merchant payment scenario, where no debtor account informaiton is supplied in the API request (account information)[] (only creditor/merchant information is supplied in the API request).  Field is optional, and at the same object tree depth as CreditorName.

--- a/payment-initiation-nz-swagger.yaml
+++ b/payment-initiation-nz-swagger.yaml
@@ -11,8 +11,8 @@ info:
   license:
     name: Licence
     url: 'http://www.paymentsnz.co.nz/licence'
-  version: v0.0.5
-basePath: /open-banking/v1
+  version: v0.1.0
+basePath: /open-banking/v0.1
 schemes:
   - https
 produces:


### PR DESCRIPTION
At the request of the standards sub-group I have bumped the version of the API specification to v0.1.0 and reflected this in the API base path.