### PR TITLE
OpenID Connect re-introduced

### DIFF
--- a/payment-initiation-nz-changelog.md
+++ b/payment-initiation-nz-changelog.md
@@ -1,7 +1,15 @@
 # Payments API changelog
 
 ---
+
+## V0.2.0 - 15/06/2018
+
+* Version bump to v0.2.0 indicating re-inclusion of OpenID Connect into authorisation flow
+* Basepath changed to /open-banking-nz/v0.2
+* Minor correction to enums where 'BECSElectronicCredit' was erroneously 'BECS Electronic Credit' (enum values should not have spaces)
+
 ## V0.1.2 - 6/06/2018
+
 * Changing URL to open-banking-nz
 * Add 501 status for optional APIs
 

--- a/payment-initiation-nz-swagger.yaml
+++ b/payment-initiation-nz-swagger.yaml
@@ -11,8 +11,8 @@ info:
   license:
     name: Licence
     url: 'http://www.paymentsnz.co.nz/licence'
-  version: v0.1.2
-basePath: /open-banking-nz/v0.1
+  version: v0.2.0
+basePath: /open-banking-nz/v0.2
 schemes:
   - https
 produces:
@@ -632,8 +632,8 @@ definitions:
             enum:
               - IBAN
               - SortCodeAccountNumber
-              - BECS Electronic Credit
-            default: BECS Electronic Credit
+              - BECSElectronicCredit
+            default: BECSElectronicCredit
           Identification:
             description: >-
               Identification assigned by an institution to identify an account.
@@ -710,8 +710,8 @@ definitions:
             enum:
               - IBAN
               - SortCodeAccountNumber
-              - BECS Electronic Credit
-            default: BECS Electronic Credit
+              - BECSElectronicCredit
+            default: BECSElectronicCredit
           Identification:
             description: >-
               Identification assigned by an institution to identify an account.


### PR DESCRIPTION
Version bump to v0.2.0, updated URL to denote re-introduction of OpenID Connect.  Minor correction to remove spaces from enum value.