### PR TITLE
Include payment initiation in submission response

### DIFF
--- a/payment-initiation-nz-changelog.md
+++ b/payment-initiation-nz-changelog.md
@@ -2,6 +2,12 @@
 
 ---
 
+## V0.3.0 - 16/11/2018
+
+Add full payment data to `payment-submissions` response (`GET` and `POST`). **Note:** this is different to upstream, but supports identification of debtor account for refund scenarios.
+
+Version bump in swagger specification to v0.3.0 and URL to v0.3.
+
 ## V0.2.1 - 26/07/2018
 
 Add Risk section in, same as upstream standard.

--- a/payment-initiation-nz-swagger.yaml
+++ b/payment-initiation-nz-swagger.yaml
@@ -11,8 +11,8 @@ info:
   license:
     name: Licence
     url: 'http://www.paymentsnz.co.nz/licence'
-  version: v0.2.1
-basePath: /open-banking-nz/v0.2
+  version: v0.3.0
+basePath: /open-banking-nz/v0.3
 schemes:
   - https
 produces:
@@ -594,10 +594,13 @@ definitions:
           2017-04-05T10:43:07+00:00
         type: string
         format: date-time
+      Initiation:
+        $ref: "#/definitions/PaymentInitiation"
     required:
       - PaymentSubmissionId
       - PaymentId
       - CreationDateTime
+      - Initiation
     additionalProperties: false
   PaymentResponse:
     description: Response that reflects the status of payment setup


### PR DESCRIPTION
As per the decision at the working group, specification has been updated to return full payment initiation data in the payment-submission responses.  This reflects the intent of Allister's submission to the group.