### PR TITLE
Minor bugfix - add missing 'type' information to definitions

### DIFF
--- a/payment-initiation-nz-swagger.yaml
+++ b/payment-initiation-nz-swagger.yaml
@@ -513,6 +513,7 @@ definitions:
         additionalProperties: false
     additionalProperties: false
   BECSRemittance:
+    type: object
     description: >-
       Remittance information for use with BECS Electronic Credit payment scheme.
       The Particulars, Code and Reference fields are currently constrained to
@@ -556,6 +557,7 @@ definitions:
       - CreditorName
     additionalProperties: false
   PaymentSubmissionResponse:
+    type: object
     description: Response that reflects the payment processing status
     properties:
       PaymentSubmissionId:
@@ -603,6 +605,7 @@ definitions:
       - Initiation
     additionalProperties: false
   PaymentResponse:
+    type: object
     description: Response that reflects the status of payment setup
     properties:
       PaymentId:


### PR DESCRIPTION
@SakerGT (Nigel) has made changes to the 'type' information in definitions and has advised these are purely mechanical and will not cause any side-effects as tested in personal repo. Therefore this will be force merged to allow for continued focus on key action points identified at Fridays sub-group session.