### PR TITLE
Payment multi authorisation

### DIFF
--- a/working/v3.0.0-draft1/payment-initiation-nz-openapi.yaml
+++ b/working/v3.0.0-draft1/payment-initiation-nz-openapi.yaml
@@ -1135,6 +1135,7 @@ components:
                 when  combined with Particulars and Code, unambiguously refer to
                 the  payment transaction.
               maxLength: 12
+          additionalProperties: false
         DebtorName:
           type: string
           description: The Debtor's Name.
@@ -1163,6 +1164,7 @@ components:
                 when  combined with Particulars and Code, unambiguously refer to
                 the  payment transaction.
               maxLength: 12
+          additionalProperties: false
       required:
         - CreditorName
       additionalProperties: false

--- a/working/v3.0.0-draft1/payment-initiation-nz-openapi.yaml
+++ b/working/v3.0.0-draft1/payment-initiation-nz-openapi.yaml
@@ -401,7 +401,9 @@ paths:
                 type: object
                 properties:
                   Data:
-                    $ref: "#/components/schemas/DomesticPaymentResponse"
+                    $ref: "#/components/schemas/DomesticPaymentResponse" 
+                  MultiAuthorisation:
+                    $ref: "#/components/schemas/MultiAuthorisationResponse"
                   Risk:
                     $ref: "#/components/schemas/Risk"
                   Links:
@@ -1362,6 +1364,33 @@ components:
         - StatusUpdateDateTime
         - Initiation
       additionalProperties: false
+    MultiAuthorisationResponse:
+      type: object
+      description: The multiple authorisation flow response from the API Provider.
+      required:
+        - Status
+      properties:
+        Status:
+          description: Specifies the status of the authorisation flow in code form.
+          type: string
+          enum:
+            - Authorised
+            - AwaitingFurtherAuthorisation
+            - Rejected
+        NumberRequired:
+          description: Number of authorisations required for payment order (total required at the start of the multi authorisation journey).
+          type: integer
+        NumberReceived:
+          description: Number of authorisations received.
+          type: integer
+        LastUpdateDateTime:
+          description: Last date and time at the authorisation flow was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00
+          type: string
+          format: date-time
+        ExpirationDateTime:
+          description: Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00
+          type: string
+          format: date-time
     DomesticPaymentDebtorAccountResponse:
       type: object
       description: Response data

--- a/working/v3.0.0-draft1/payment-initiation-nz-openapi.yaml
+++ b/working/v3.0.0-draft1/payment-initiation-nz-openapi.yaml
@@ -1369,6 +1369,7 @@ components:
       description: The multiple authorisation flow response from the API Provider.
       required:
         - Status
+      additionalProperties: false
       properties:
         Status:
           description: Specifies the status of the authorisation flow in code form.

--- a/working/v3.0.0-draft1/payment-initiation-nz-openapi.yaml
+++ b/working/v3.0.0-draft1/payment-initiation-nz-openapi.yaml
@@ -401,9 +401,7 @@ paths:
                 type: object
                 properties:
                   Data:
-                    $ref: "#/components/schemas/DomesticPaymentResponse" 
-                  MultiAuthorisation:
-                    $ref: "#/components/schemas/MultiAuthorisationResponse"
+                    $ref: "#/components/schemas/DomesticPaymentResponse"
                   Risk:
                     $ref: "#/components/schemas/Risk"
                   Links:
@@ -1248,6 +1246,8 @@ components:
       properties:
         Consent:
           $ref: "#/components/schemas/DomesticConsent"
+        Authorisation:
+          $ref: "#/components/schemas/Authorisation"
       required:
         - Consent
       additionalProperties: false
@@ -1290,6 +1290,8 @@ components:
           format: date-time
         Consent:
           $ref: "#/components/schemas/DomesticConsent"
+        Authorisation:
+          $ref: "#/components/schemas/Authorisation"
       required:
         - ConsentId
         - Status
@@ -1358,6 +1360,8 @@ components:
           format: date-time
         Initiation:
           $ref: "#/components/schemas/DomesticConsent"
+        MultiAuthorisation:
+          $ref: "#/components/schemas/MultiAuthorisationResponse"
       required:
         - DomesticPaymentId
         - ConsentId
@@ -1366,6 +1370,23 @@ components:
         - StatusUpdateDateTime
         - Initiation
       additionalProperties: false
+    Authorisation:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "AuthorisationType"
+      description: "The authorisation type request from the TPP."
+      properties:
+        AuthorisationType:
+          description: "Type of authorisation flow requested."
+          type: "string"
+          enum:
+            - "Any"
+            - "Single"
+        CompletionDateTime:
+          description: "Date and time at which the requested authorisation flow must be completed. All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+          type: "string"
+          format: "date-time"
     MultiAuthorisationResponse:
       type: object
       description: The multiple authorisation flow response from the API Provider.
@@ -1540,6 +1561,8 @@ components:
       properties:
         Consent:
           $ref: "#/components/schemas/EnduringConsent"
+        Authorisation:
+          $ref: "#/components/schemas/Authorisation"
       required:
         - Consent
       additionalProperties: false
@@ -1582,6 +1605,8 @@ components:
           format: date-time
         Consent:
           $ref: "#/components/schemas/EnduringConsent"
+        Authorisation:
+          $ref: "#/components/schemas/Authorisation"
       required:
         - ConsentId
         - Status

--- a/working/v3.0.0-draft1/payment-initiation-nz-openapi.yaml
+++ b/working/v3.0.0-draft1/payment-initiation-nz-openapi.yaml
@@ -1371,22 +1371,29 @@ components:
         - Initiation
       additionalProperties: false
     Authorisation:
-      type: "object"
+      type: object
       additionalProperties: false
       required:
-        - "AuthorisationType"
-      description: "The authorisation type request from the TPP."
+        - AuthorisationType
+      description: The authorisation type request from the Third Party.
       properties:
         AuthorisationType:
-          description: "Type of authorisation flow requested."
-          type: "string"
+          description: Type of authorisation flow requested.
+          type: string
           enum:
-            - "Any"
-            - "Single"
+            - Any
+            - Single
         CompletionDateTime:
-          description: "Date and time at which the requested authorisation flow must be completed. All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
-          type: "string"
-          format: "date-time"
+          description: >-
+            Date and time at which the requested authorisation flow must be 
+            completed. All dates in the JSON payloads are represented in ISO 8601
+            date-time format.
+            
+            All date-time fields in responses must include the timezone. 
+            
+            An example is: 2017-04-05T10:43:07+00:00
+          type: string
+          format: date-time
     MultiAuthorisationResponse:
       type: object
       description: The multiple authorisation flow response from the API Provider.
@@ -1402,17 +1409,32 @@ components:
             - AwaitingFurtherAuthorisation
             - Rejected
         NumberRequired:
-          description: Number of authorisations required for payment order (total required at the start of the multi authorisation journey).
+          description: >-
+            Number of authorisations required for payment order (total required at the
+            start of the multi authorisation journey).
           type: integer
         NumberReceived:
           description: Number of authorisations received.
           type: integer
         LastUpdateDateTime:
-          description: Last date and time at the authorisation flow was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00
+          description: >- 
+            Last date and time at the authorisation flow was updated.
+            All dates in the JSON payloads are represented in ISO 8601 date-time format.
+            
+            All date-time fields in responses must include the timezone. 
+            
+            An example is below: 2017-04-05T10:43:07+00:00
           type: string
           format: date-time
         ExpirationDateTime:
-          description: Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00
+          description: >-
+            Date and time at which the requested authorisation flow must be
+            completed.  All dates in the JSON payloads are represented in ISO 8601 
+            date-time format.
+            
+            All date-time fields in responses must include the timezone. 
+            
+            An example is: 2017-04-05T10:43:07+00:00
           type: string
           format: date-time
     DomesticPaymentDebtorAccountResponse:


### PR DESCRIPTION
Update the OpenAPI specification so it is consistent with the V3.0.0-draft1 specifications in confluence.  Added optional Authorisation object in Domestic Payment Consent and Enduring Payment Consent to reflect upstream changes and align with Confluence documents.