### PR TITLE
V3.0.0-rc2 and remove multi-auth

### DIFF
--- a/working/v3.0.0-rc2/README.md
+++ b/working/v3.0.0-rc2/README.md
@@ -1,8 +1,8 @@
 # Payment Initiation
 
-## V3.0.0-rc1
+## V3.0.0-rc2
 
-This is v3.0.0-rc1 NZ Open Banking Payment Initiation API technical specification.
+This is v3.0.0-rc2 NZ Open Banking Payment Initiation API technical specification.
 
 The `AuthorizationParam` definition and references have been removed.  Header parameters named `Authorization` are [ignored in OpenAPI 3](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#user-content-parametername); `securitySchemes` and `security` should be used instead.
 

--- a/working/v3.0.0-rc2/payment-initiation-nz-openapi.yaml
+++ b/working/v3.0.0-rc2/payment-initiation-nz-openapi.yaml
@@ -12,7 +12,7 @@ info:
   license:
     name: Licence
     url: https://www.apicentre.paymentsnz.co.nz/join/
-  version: v3.0.0-rc1
+  version: v3.0.0-rc2
 paths:
   /enduring-payment-consents:
     post:
@@ -1247,8 +1247,6 @@ components:
       properties:
         Consent:
           $ref: "#/components/schemas/DomesticConsent"
-        Authorisation:
-          $ref: "#/components/schemas/Authorisation"
       required:
         - Consent
       additionalProperties: false
@@ -1291,8 +1289,6 @@ components:
           format: date-time
         Consent:
           $ref: "#/components/schemas/DomesticConsent"
-        Authorisation:
-          $ref: "#/components/schemas/Authorisation"
       required:
         - ConsentId
         - Status
@@ -1361,8 +1357,6 @@ components:
           format: date-time
         Initiation:
           $ref: "#/components/schemas/DomesticConsent"
-        MultiAuthorisation:
-          $ref: "#/components/schemas/MultiAuthorisationResponse"
       required:
         - DomesticPaymentId
         - ConsentId
@@ -1371,73 +1365,6 @@ components:
         - StatusUpdateDateTime
         - Initiation
       additionalProperties: false
-    Authorisation:
-      type: object
-      additionalProperties: false
-      required:
-        - AuthorisationType
-      description: The authorisation type request from the Third Party.
-      properties:
-        AuthorisationType:
-          description: Type of authorisation flow requested.
-          type: string
-          enum:
-            - Any
-            - Single
-        CompletionDateTime:
-          description: >-
-            Date and time at which the requested authorisation flow must be 
-            completed. All dates in the JSON payloads are represented in ISO 8601
-            date-time format.
-            
-            All date-time fields in responses must include the timezone. 
-            
-            An example is: 2017-04-05T10:43:07+00:00
-          type: string
-          format: date-time
-    MultiAuthorisationResponse:
-      type: object
-      description: The multiple authorisation flow response from the API Provider.
-      required:
-        - Status
-      additionalProperties: false
-      properties:
-        Status:
-          description: Specifies the status of the authorisation flow in code form.
-          type: string
-          enum:
-            - Authorised
-            - AwaitingFurtherAuthorisation
-            - Rejected
-        NumberRequired:
-          description: >-
-            Number of authorisations required for payment order (total required at the
-            start of the multi authorisation journey).
-          type: integer
-        NumberReceived:
-          description: Number of authorisations received.
-          type: integer
-        LastUpdateDateTime:
-          description: >- 
-            Last date and time at the authorisation flow was updated.
-            All dates in the JSON payloads are represented in ISO 8601 date-time format.
-            
-            All date-time fields in responses must include the timezone. 
-            
-            An example is below: 2017-04-05T10:43:07+00:00
-          type: string
-          format: date-time
-        ExpirationDateTime:
-          description: >-
-            Date and time at which the requested authorisation flow must be
-            completed.  All dates in the JSON payloads are represented in ISO 8601 
-            date-time format.
-            
-            All date-time fields in responses must include the timezone. 
-            
-            An example is: 2017-04-05T10:43:07+00:00
-          type: string
-          format: date-time
     DomesticPaymentDebtorAccountResponse:
       type: object
       description: Response data
@@ -1584,8 +1511,6 @@ components:
       properties:
         Consent:
           $ref: "#/components/schemas/EnduringConsent"
-        Authorisation:
-          $ref: "#/components/schemas/Authorisation"
       required:
         - Consent
       additionalProperties: false
@@ -1628,8 +1553,6 @@ components:
           format: date-time
         Consent:
           $ref: "#/components/schemas/EnduringConsent"
-        Authorisation:
-          $ref: "#/components/schemas/Authorisation"
       required:
         - ConsentId
         - Status


### PR DESCRIPTION
This pull request aligns the payment initiation API with the decision (BWG 1/09/2023 and API Council 11/09/2023) to de-scope multi-authorisation until a later version, and the issues can be worked through fully.

Version number updated to v3.0.0-rc2.