### PR TITLE
Risk updates, spelling fixes and lint tidy-up

### DIFF
--- a/working/v3.0.0-rc2/payment-initiation-nz-openapi.yaml
+++ b/working/v3.0.0-rc2/payment-initiation-nz-openapi.yaml
@@ -560,12 +560,12 @@ paths:
         - ThirdPartyOAuth2Security:
             - payments
 tags:
-  - name: Enduring Payment Consents
-    description: Long lived payment-order consent
   - name: Domestic Payment Consents
     description: Short lived payment-order consent
   - name: Domestic Payments
     description: Single, domestic, electronic credit payment-order
+  - name: Enduring Payment Consents
+    description: Long lived payment-order consent
 servers:
   - url: https://api.provider.co.nz/open-banking-nz/v3.0
 components:

--- a/working/v3.0.0-rc2/payment-initiation-nz-openapi.yaml
+++ b/working/v3.0.0-rc2/payment-initiation-nz-openapi.yaml
@@ -1091,6 +1091,16 @@ components:
           type: string
           minLength: 1
           maxLength: 14
+        EndUserCompanyName:
+          description: Name of the end user facing organisation
+          type: string
+          minLength: 1
+          maxLength: 70
+        EndUserCompanyNZBN:
+          description: NZ business number for the end user facing organisation
+          type: string
+          minLength: 1
+          maxLength: 70
         MerchantName:
           description: Name of the merchant
           type: string

--- a/working/v3.0.0-rc2/payment-initiation-nz-openapi.yaml
+++ b/working/v3.0.0-rc2/payment-initiation-nz-openapi.yaml
@@ -992,12 +992,12 @@ components:
           type: object
           properties:
             Latitude:
-              description: Latitude measured in decimal degress
+              description: Latitude measured in decimal degrees
               type: string
               maxLength: 14
               pattern: ^-?\d{1,3}\.\d{1,8}$
             Longitude:
-              description: Longitude measured in decimal degress
+              description: Longitude measured in decimal degrees
               type: string
               maxLength: 14
               pattern: ^-?\d{1,3}\.\d{1,8}$


### PR DESCRIPTION
As per TWG [tech decision 050](https://paymentsnz.atlassian.net/wiki/spaces/PaymentsDirectionAPIStandardsDevelopment/pages/1659109377/Technical+Decision+-+050+-+Risk+object+additional+parties), the Risk object has been updated to include `EndUserCompanyName` and `EndUserCompanyNZBN` as optional fields.

Spelling mistakes have been corrected per JIRA [item 701](https://paymentsnz.atlassian.net/browse/PNZAC-701), and tags have been tidied to please the OpenAPI linter.